### PR TITLE
Level Advancement w/ Curriculum Learning 

### DIFF
--- a/Assets/FPS/Scripts/Gameplay/Nautica/BotKillerAgent.cs
+++ b/Assets/FPS/Scripts/Gameplay/Nautica/BotKillerAgent.cs
@@ -63,6 +63,7 @@ namespace Nautica
 			// DANGER: this assumes agent is nested under the level prefab
 			// TrainingManager shuffles agents around to different levels, so need to be careful
 			var trainingLevelManager = transform.parent.GetComponent<TrainingLevelManager>();
+
 			if (!trainingLevelManager)
 			{
 				Debug.unityLogger.Log(LOGTAG, "Could not find TrainingLevelManager!");
@@ -294,9 +295,7 @@ namespace Nautica
 			LookVertical = discreteActions[4];
 
 			// reward shaping testing: reward based on angle to enemy
-			const float enemy_angle_reward_threshold = 0.1f;  // reward agent if ANY enemies angle is < enemy_angle_reward, agent pointing directly at an enemy and shooting
 			const float enemy_angle_penalty_threshold = 0.5f;  // penalize agent if ALL enemy angles are > enemy_angle_penalty, agent is shooting away from all enemies not even close
-			const float enemy_angle_reward = 0.01f;
 			const float enemy_angle_penalty = -0.01f;
 			// NOTE: this gets called 5 times per step by default,
 			// this is because the agent default DecisionRequester only requests decisions every 5 frames,

--- a/Assets/FPS/Scripts/Gameplay/Nautica/TrainingLevelManager.cs
+++ b/Assets/FPS/Scripts/Gameplay/Nautica/TrainingLevelManager.cs
@@ -37,70 +37,128 @@ namespace Nautica {
 		/// <param name="newAgent">The agent to use, or null</param>
 		public void SetAgent(GameObject newAgent)
 		{
+			CreateNewAgent(newAgent);
+			ResetAgentAnchor();
+			SetActorManager();
+		}
+
+		private void CreateNewAgent(GameObject newAgent)
+        {
 			agentObj = newAgent;  // regardless of whether this is null, because we may want to unset it
 
 			if (agentObj)
 			{
 				agent = agentObj.GetComponent<AbstractNauticaAgent>();
 			}
+		}
 
-			if (agentAnchor)
+		private void ResetAgentAnchor()
+        {
+			if (agentAnchor == null) return;
+
+			var agentResetAnchor = agentAnchor.GetComponent<AgentResetAnchor>();
+			if (agentResetAnchor)
 			{
-				var agentResetAnchor = agentAnchor.GetComponent<AgentResetAnchor>();
-				if (agentResetAnchor)
-				{
-					agentResetAnchor.entity = agentObj;
-				}
+				agentResetAnchor.entity = agentObj;
 			}
+		}
 
+		private void SetActorManager()
+        {
 			var actorsManager = GetComponent<ActorsManager>();
-			if (actorsManager)
+
+			if (actorsManager == null) return;
+
+			SetAgentAsPlayerInActorsManager(actorsManager);
+		}
+
+		private void SetAgentAsPlayerInActorsManager(ActorsManager actorsManager)
+        {
+			actorsManager.SetPlayer(agentObj);
+
+			if (agentObj == null) return;
+
+			AddPlayerActorToListOfActors(actorsManager);
+		}
+
+		private void AddPlayerActorToListOfActors(ActorsManager actorsManager)
+        {
+			var agentActor = agentObj.GetComponent<Actor>();
+			if (agentAnchor == null) return;
+
+			if (!actorsManager.Actors.Contains(agentActor))
 			{
-				// set actor manager player
-				actorsManager.SetPlayer(agentObj);
-				if (agentObj)
-				{
-					// add player Actor component to list of actors
-					var agentActor = agentObj.GetComponent<Actor>();
-					if (agentActor)
-					{
-						if (!actorsManager.Actors.Contains(agentActor))
-						{
-							actorsManager.Actors.Add(agentActor);
-						}
-					}
-				}
+				actorsManager.Actors.Add(agentActor);
 			}
 		}
 
 		void FixedUpdate()
 		{
-			if (Academy.Instance.StepCount == 0) return;
-			if (!agentObj || !agent) return;
+			if (AgentDidNotMove()) return;
+			if (AgentDoesNotExistInLevel()) return;
 
-			// check agent dead
+			CheckForEndOfEpisodeEvent();
+		}
+
+		private bool AgentDidNotMove()
+        {
+			return Academy.Instance.StepCount == 0;
+		}
+
+		private bool AgentDoesNotExistInLevel()
+        {
+			return !agentObj || !agent;
+		}
+
+		private void CheckForEndOfEpisodeEvent()
+        {
+			if (AgentIsDead())
+			{
+				RewardAgent(LoseReward, "Agent loses, cumulative reward = ");
+				return;
+			}
+
+			if (AllEnemiesAreDead())
+			{
+				RewardAgent(WinReward, "Agent wins, cumulative reward = ");
+				MoveToNextLevel();
+				return; 
+			}
+
+			if (AgentReachedMaxSteps())
+			{
+				RewardAgent(0.0f, "Agent reached MAX_STEPS, cumulative reward = ");
+			}
+		}
+		
+		private bool AgentIsDead()
+		{
 			var agentHealth = agentObj.GetComponent<Health>();
-			if (agentHealth && agentHealth.CurrentHealth <= 0)
-			{
-				agent.AddReward(LoseReward);
-				Debug.unityLogger.Log(LOGTAG, "Agent loses, cumulative reward = " + agent.GetCumulativeReward());
-				Reset();
-			}
+			return agentHealth && agentHealth.CurrentHealth <= 0;
+		}
 
-			// check all enemies dead
-			else if (enemies.All(e => e != null && e.GetComponent<Health>().CurrentHealth <= 0))
-			{
-				agent.AddReward(WinReward);
-				Debug.unityLogger.Log(LOGTAG, "Agent wins, cumulative reward = " + agent.GetCumulativeReward());
-				Reset();
-			}
+		private void RewardAgent(float reward, String message)
+        {
+			agent.AddReward(reward);
+			Debug.unityLogger.Log(LOGTAG, message + agent.GetCumulativeReward());
+			Reset();
+		}
 
-			else if (agent.StepCount >= agent.MaxStep-1)
-			{
-				agent.AddReward(0.0f);
-				Debug.unityLogger.Log(LOGTAG, "Agent reached MAX_STEPS, cumulative reward = " + agent.GetCumulativeReward());
-				Reset();
-			}
+		public bool AllEnemiesAreDead()
+        {
+			return enemies.All(e => e != null && e.GetComponent<Health>().CurrentHealth <= 0);
+		}
+
+		private bool AgentReachedMaxSteps()
+        {
+			return agent.StepCount >= agent.MaxStep - 1; 
+        }
+
+		private void MoveToNextLevel()
+		{
+			GameObject challengeManager = GameObject.Find("TrainingManager");
+			var trainingManager = challengeManager.GetComponent<TrainingManager>();
+			trainingManager.SetUpNextLevel();
 		}
 
 		public void Reset()

--- a/Assets/FPS/Scripts/Gameplay/Nautica/TrainingLevelManager.cs
+++ b/Assets/FPS/Scripts/Gameplay/Nautica/TrainingLevelManager.cs
@@ -156,10 +156,29 @@ namespace Nautica {
 
 		private void MoveToNextLevel()
 		{
-			GameObject challengeManager = GameObject.Find("TrainingManager");
-			var trainingManager = challengeManager.GetComponent<TrainingManager>();
+			GameObject manager = FindManager();
+			if (manager == null) return;
+
+			var trainingManager = manager.GetComponent<TrainingManager>();
 			trainingManager.SetUpNextLevel();
 		}
+
+		private GameObject FindManager()
+        {
+			GameObject manager = GameObject.Find("TrainingManager");
+			if (manager != null)
+			{
+				return manager;
+			}
+
+			manager = GameObject.Find("ChallengeManager");
+			if (manager != null)
+			{
+				return manager;
+			}
+
+			return null;
+        }
 
 		public void Reset()
 		{

--- a/Assets/FPS/Scripts/Gameplay/Nautica/TrainingManager.cs
+++ b/Assets/FPS/Scripts/Gameplay/Nautica/TrainingManager.cs
@@ -28,16 +28,21 @@ namespace Nautica {
 		public GameObject agentPrefab;
 		public List<GameObject> levels = new List<GameObject>();
 		private List<TrainingLevelManager> trainingLevelManagers = new List<TrainingLevelManager>();
-        public bool humanControl = false;
+		public bool humanControl = false;
+		private bool inTrainingMode = false; 
         public bool debugOutput = false;
         private const string LOGTAG = nameof(TrainingManager);
-		public int lastLevel = 3; 
+		public int lastLevel = 3;
 
         void Start()
         {
 			SetupLevels();
 
-			if (Academy.Instance.IsCommunicatorOn) humanControl = false;  // when in training mode, force agent control
+			if (Academy.Instance.IsCommunicatorOn)
+			{
+				humanControl = false;  // when in training mode, force agent control
+				inTrainingMode = true;
+			}
         }
 
 		private void SetupLevels()
@@ -158,15 +163,17 @@ namespace Nautica {
 		{
 			if (nextLevel >= lastLevel) return;
 
-			if (humanControl)
+			if (inTrainingMode)
 			{
-				nextLevel++;
+				nextLevel = (int)Academy.Instance.EnvironmentParameters.GetWithDefault("level", nextLevel);
+				Debug.Log("nextLevel via Training mode: " + nextLevel);
 			}
 			else
 			{
-				nextLevel = (int)Academy.Instance.EnvironmentParameters.GetWithDefault("level", nextLevel);
+				nextLevel++;
+				Debug.Log("nextLevel via humanControl: " + nextLevel);
 			}
-			
+
 			SwitchLevel();
 		}
 	}

--- a/Assets/FPS/Scripts/Gameplay/Nautica/TrainingManager.cs
+++ b/Assets/FPS/Scripts/Gameplay/Nautica/TrainingManager.cs
@@ -33,17 +33,27 @@ namespace Nautica {
         public bool debugOutput = false;
         private const string LOGTAG = nameof(TrainingManager);
 		public int lastLevel = 3;
+		private bool inChallengeTrials = false;
 
         void Start()
         {
+			SetupEnvironmentMode();
 			SetupLevels();
+		}
 
+		private void SetupEnvironmentMode()
+		{
 			if (Academy.Instance.IsCommunicatorOn)
 			{
 				humanControl = false;  // when in training mode, force agent control
 				inTrainingMode = true;
 			}
-        }
+
+			if(this.transform.parent.name == "ChallengeManager")
+            {
+				inChallengeTrials = true;
+            }
+		}
 
 		private void SetupLevels()
         {
@@ -163,15 +173,13 @@ namespace Nautica {
 		{
 			if (nextLevel >= lastLevel) return;
 
-			if (inTrainingMode)
+			if (inTrainingMode && !inChallengeTrials) //TODO: test w/ Nick's Score-Manager branch to see if inChallengeTrials work
 			{
 				nextLevel = (int)Academy.Instance.EnvironmentParameters.GetWithDefault("level", nextLevel);
-				Debug.Log("nextLevel via Training mode: " + nextLevel);
 			}
 			else
 			{
 				nextLevel++;
-				Debug.Log("nextLevel via humanControl: " + nextLevel);
 			}
 
 			SwitchLevel();

--- a/Assets/Scenes/Training for the Challenge/Training Main Scene.unity
+++ b/Assets/Scenes/Training for the Challenge/Training Main Scene.unity
@@ -864,6 +864,11 @@ PrefabInstance:
         type: 3}
     - target: {fileID: 5053595164199898323, guid: 1f409385cb77e1642b06322a2fb9f71b,
         type: 3}
+      propertyPath: humanControl
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5053595164199898323, guid: 1f409385cb77e1642b06322a2fb9f71b,
+        type: 3}
       propertyPath: levels.Array.size
       value: 8
       objectReference: {fileID: 0}

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,4 +1,7 @@
 ## Beta
+- 12 Aug 2021 Patch release
+  - Restructured/refactored/cleaned-up Botkiller agent script for ease of code review, training, etc.
+  - Known issue: Rare event where the agent may log excessive damage after a single hit, after running up to a bot and then running away.
 - 29 Jul 2021 New feature release
   - All levels are ready for agent training.
     - Switching levels for agent training now easier... just update "next level" (don't change "current level").  


### PR DESCRIPTION
Level Advancement update works for the Training Scene. In addition, level advancement works for human, training, and .onnx controlled agents. The `private bool inChallengeTrials` in TrainingManager.cs is for level advancement in the Challenge Scene being worked on in the Score-Manager branch. 

### TrainingManager.cs 
#### Methods for Level Advancement
- SetUpNextLevel()
- SwitchLevel() --> pulled out from FixedUpdate()
#### Refactored Methods
- SetupLevels()
- ActivateCurrentLevelOnly()
- InstantiateAgentUsingAgentAnchor()
- SwapToNewAnchor()

### TrainingLevelManager.cs
#### Methods for Level Advancement
- MoveToNextLevel()
- FindManager()
#### Refactored Methods
- CreateNewAgent()
- ResetAgentAnchor()
- SetActorManager()
- SetAgentAsPlayerInActorsManager()
- AddPlayerActorToListOfActors()
- AgentDidNotMove()
- AgentDoesNotExistInLevel()
- CheckForEndOfEpisodeEvent()
- AgentIsDead()
- RewardAgent()
- AllEnemiesAreDead()
- AgentReachedMaxSteps()

**Note: Level Advancement `inTrainingMode` is dependent on all enemies being defeated and the lesson number (lesson number changes based on reward threshold)